### PR TITLE
Add Option to Reset After Delay

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -20,13 +20,19 @@
                 "title": "Randomize After Delay?",
                 "type": "boolean",
                 "default": true,
-                "description": "If set, the counter will pick a new random number after the specified delay."
+                "description": "If set, the counter will pick a new random number after the specified delay (takes precedence over Reset After Delay)."
+            },
+            "resetAfterDelay": {
+                "title": "Reset After Delay?",
+                "type": "boolean",
+                "default": false,
+                "description": "If set, the counter will be reset to 0 after the specified delay (Randomize After Delay must be false)."
             },
             "delay": {
                 "title": "Delay",
                 "type": "number",
                 "default": 300000,
-                "description": "How long after the index is changed to randomize, in milliseconds."
+                "description": "How long after the index is changed to randomize or reset, in milliseconds."
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-index-counter",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Simple counter for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [


### PR DESCRIPTION
I've updated homebridge-index-counter with an additional setting that resets the counter after the configured delay instead of randomizing. Please let me know if you have any questions or concerns about my changes. Thanks!